### PR TITLE
Create build-and-publish.yml

### DIFF
--- a/.github/build-and-publish.yml
+++ b/.github/build-and-publish.yml
@@ -1,0 +1,26 @@
+name: Build and publish to gh-pages
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v1
+      - name: Compile main-german.tex
+        uses: dante-ev/latex-action@master
+        with:
+          root_file: lfgw.tex
+          args:
+      - name: Gather build artifacts
+        run: mkdir build && cp -lfgw.pdf build/
+      - name: Deploy
+        if: success()
+        uses: crazy-max/ghaction-github-pages@master
+        with:
+          target_branch: gh-pages
+          build_dir: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Initiale GitHub Workflow config.

Fixes https://github.com/thomas-hilarius-meyer/LaTeX-fuer-Geisteswissenschaftler/issues/118

@thomas-hilarius-meyer Du musst "nur noch" die Variable `ACCESS_TOKEN` anlegen:

1. https://github.com/settings/tokens aufrufen (Profile -> Settings -> Developer Settings -> Pesonal Access Tokens)
2. "Generate new token"
3. Note: "LFGW"
4. Scope: Nur "public_repo" (unter "repo")
5. "Generate token" klicken
6. String kopieren
7. https://github.com/thomas-hilarius-meyer/LaTeX-fuer-Geisteswissenschaftler/settings/secrets aufrufen.
8. "Add a new secret"
9. Name: "GitHub"
10. Value: Den String aus Schritt 6 einfügen
11. "Add secret"

Schon sollte es gehen und bei der nächsten Änderung, im branch `gh-pages` das PDF liegen.